### PR TITLE
Added method to get current capacity of rate limiter for given algorithm

### DIFF
--- a/src/Aeon/RateLimiter/Algorithm.php
+++ b/src/Aeon/RateLimiter/Algorithm.php
@@ -17,5 +17,10 @@ interface Algorithm
     /**
      * Estimate the time in which next hit is allowed.
      */
-    public function nextHit(string $id, Storage $storage) : TimeUnit;
+    public function estimate(string $id, Storage $storage) : TimeUnit;
+
+    /**
+     * Return hits left before throttling next hit.
+     */
+    public function capacity(string $id, Storage $storage) : int;
 }

--- a/src/Aeon/RateLimiter/Algorithm/LeakyBucketAlgorithm.php
+++ b/src/Aeon/RateLimiter/Algorithm/LeakyBucketAlgorithm.php
@@ -48,7 +48,7 @@ final class LeakyBucketAlgorithm implements Algorithm
     /**
      * @psalm-suppress PossiblyNullReference
      */
-    public function nextHit(string $id, Storage $storage) : TimeUnit
+    public function estimate(string $id, Storage $storage) : TimeUnit
     {
         $hits = $storage->all($id);
 
@@ -58,5 +58,12 @@ final class LeakyBucketAlgorithm implements Algorithm
         }
 
         return TimeUnit::seconds(0);
+    }
+
+    public function capacity(string $id, Storage $storage) : int
+    {
+        $hits = $storage->all($id);
+
+        return $this->bucketSize - $hits->count();
     }
 }

--- a/src/Aeon/RateLimiter/Algorithm/SlidingWindowAlgorithm.php
+++ b/src/Aeon/RateLimiter/Algorithm/SlidingWindowAlgorithm.php
@@ -43,7 +43,7 @@ final class SlidingWindowAlgorithm implements Algorithm
     /**
      * @psalm-suppress PossiblyNullReference
      */
-    public function nextHit(string $id, Storage $storage) : TimeUnit
+    public function estimate(string $id, Storage $storage) : TimeUnit
     {
         $hits = $storage->all($id);
 
@@ -53,5 +53,12 @@ final class SlidingWindowAlgorithm implements Algorithm
         }
 
         return TimeUnit::seconds(0);
+    }
+
+    public function capacity(string $id, Storage $storage) : int
+    {
+        $hits = $storage->all($id);
+
+        return $this->limit - $hits->count();
     }
 }

--- a/src/Aeon/RateLimiter/RateLimiter.php
+++ b/src/Aeon/RateLimiter/RateLimiter.php
@@ -30,7 +30,12 @@ final class RateLimiter
 
     public function estimate(string $id) : TimeUnit
     {
-        return $this->algorithm->nextHit($id, $this->storage);
+        return $this->algorithm->estimate($id, $this->storage);
+    }
+
+    public function capacity(string $id) : int
+    {
+        return $this->algorithm->capacity($id, $this->storage);
     }
 
     public function throttle(string $id, Process $process) : void

--- a/tests/Aeon/RateLimiter/Tests/Unit/RateLimiterTest.php
+++ b/tests/Aeon/RateLimiter/Tests/Unit/RateLimiterTest.php
@@ -33,7 +33,7 @@ final class RateLimiterTest extends TestCase
     public function test_estimate_method_throwing_exception() : void
     {
         $algorithm = $this->createStub(Algorithm::class);
-        $algorithm->method('nextHit')->willReturn(TimeUnit::second());
+        $algorithm->method('estimate')->willReturn(TimeUnit::second());
 
         $rateLimiter = new RateLimiter(
             $algorithm,
@@ -56,6 +56,19 @@ final class RateLimiterTest extends TestCase
         $process->expects($this->never())->method('sleep');
 
         $rateLimiter->throttle('id', $process);
+    }
+
+    public function test_capacity() : void
+    {
+        $algorithm = $this->createStub(Algorithm::class);
+        $algorithm->method('capacity')->willReturn(10);
+
+        $rateLimiter = new RateLimiter(
+            $algorithm,
+            $this->createMock(Storage::class)
+        );
+
+        $this->assertSame(10, $rateLimiter->capacity('id'));
     }
 
     public function test_throttle_and_wait() : void


### PR DESCRIPTION
This PR makes something I would call the final API shape

```php
    /**
     * Record next hit, throws an extension where there are no available hits left according to the selected algorithm.
     *
     * @throws RateLimitException
     */
    public function hit(string $id) : void

    /**
     * Estimate time required to the next hit. If current capacity is greater than 0, time will be 0.
     */
    public function estimate(string $id) : TimeUnit

    /**
     * Returns current capacity according to the selected algorithm, when there are no available hits left, it will return 0.
     * Use RateLimiter::estimate method to find out when next hit will be possible.
     */
    public function capacity(string $id) : int

    /**
     * Try to record next hit, in case of rate limit exception take the cooldown time and sleep current process.
     */
    public function throttle(string $id, Process $process) : void

```