### PR TITLE
Added reset in and initial capacity to the rate limiter API

### DIFF
--- a/src/Aeon/RateLimiter/Algorithm.php
+++ b/src/Aeon/RateLimiter/Algorithm.php
@@ -23,4 +23,14 @@ interface Algorithm
      * Return hits left before throttling next hit.
      */
     public function capacity(string $id, Storage $storage) : int;
+
+    /**
+     * Time required to fully reset hits limit.
+     */
+    public function resetIn(string $id, Storage $storage) : TimeUnit;
+
+    /**
+     * Initial available capacity before registering any hits or when all hits time out.
+     */
+    public function capacityInitial() : int;
 }

--- a/src/Aeon/RateLimiter/Algorithm/LeakyBucketAlgorithm.php
+++ b/src/Aeon/RateLimiter/Algorithm/LeakyBucketAlgorithm.php
@@ -28,6 +28,11 @@ final class LeakyBucketAlgorithm implements Algorithm
         $this->leakTime = $leakTime;
     }
 
+    public function capacityInitial() : int
+    {
+        return $this->bucketSize;
+    }
+
     /**
      * @psalm-suppress PossiblyNullReference
      */
@@ -65,5 +70,17 @@ final class LeakyBucketAlgorithm implements Algorithm
         $hits = $storage->all($id);
 
         return $this->bucketSize - $hits->count();
+    }
+
+    /**
+     * @psalm-suppress InvalidNullableReturnType
+     * @psalm-suppress NullableReturnStatement
+     */
+    public function resetIn(string $id, Storage $storage) : TimeUnit
+    {
+        $hits = $storage->all($id);
+
+        /** @phpstan-ignore-next-line */
+        return $hits->count() ? $hits->longestTTL($this->calendar) : TimeUnit::seconds(0);
     }
 }

--- a/src/Aeon/RateLimiter/Algorithm/SlidingWindowAlgorithm.php
+++ b/src/Aeon/RateLimiter/Algorithm/SlidingWindowAlgorithm.php
@@ -25,6 +25,11 @@ final class SlidingWindowAlgorithm implements Algorithm
         $this->timeWindow = $timeWindow;
     }
 
+    public function capacityInitial() : int
+    {
+        return $this->limit;
+    }
+
     /**
      * @psalm-suppress PossiblyNullReference
      */
@@ -60,5 +65,17 @@ final class SlidingWindowAlgorithm implements Algorithm
         $hits = $storage->all($id);
 
         return $this->limit - $hits->count();
+    }
+
+    /**
+     * @psalm-suppress InvalidNullableReturnType
+     * @psalm-suppress NullableReturnStatement
+     */
+    public function resetIn(string $id, Storage $storage) : TimeUnit
+    {
+        $hits = $storage->all($id);
+
+        /** @phpstan-ignore-next-line */
+        return $hits->count() ? $hits->longestTTL($this->calendar) : TimeUnit::seconds(0);
     }
 }

--- a/src/Aeon/RateLimiter/Hits.php
+++ b/src/Aeon/RateLimiter/Hits.php
@@ -6,6 +6,7 @@ namespace Aeon\RateLimiter;
 
 use Aeon\Calendar\Gregorian\Calendar;
 use Aeon\Calendar\Gregorian\DateTime;
+use Aeon\Calendar\TimeUnit;
 
 /**
  * @psalm-immutable
@@ -82,5 +83,24 @@ final class Hits implements \Countable
         }
 
         return $hitsData;
+    }
+
+    public function longestTTL(Calendar $calendar) : ?TimeUnit
+    {
+        $longestTTL = null;
+
+        foreach ($this->hits as $hit) {
+            if ($longestTTL === null) {
+                $longestTTL = $hit;
+
+                continue;
+            }
+
+            if ($hit->ttlLeft($calendar)->isGreaterThan($longestTTL->ttlLeft($calendar))) {
+                $longestTTL = $hit;
+            }
+        }
+
+        return $longestTTL ? $longestTTL->ttlLeft($calendar) : null;
     }
 }

--- a/src/Aeon/RateLimiter/RateLimiter.php
+++ b/src/Aeon/RateLimiter/RateLimiter.php
@@ -48,6 +48,22 @@ final class RateLimiter
     }
 
     /**
+     * Initial available capacity before registering any hits or when all hits time out.
+     */
+    public function capacityInitial() : int
+    {
+        return $this->algorithm->capacityInitial();
+    }
+
+    /**
+     * Time required to fully reset to the total capacity.
+     */
+    public function resetIn(string $id) : TimeUnit
+    {
+        return $this->algorithm->resetIn($id, $this->storage);
+    }
+
+    /**
      * Try to record next hit, in case of rate limit exception take the cooldown time and sleep current process.
      */
     public function throttle(string $id, Process $process) : void

--- a/tests/Aeon/RateLimiter/Tests/Unit/Algorithm/SlidingWindowAlgorithmTest.php
+++ b/tests/Aeon/RateLimiter/Tests/Unit/Algorithm/SlidingWindowAlgorithmTest.php
@@ -67,6 +67,9 @@ final class SlidingWindowAlgorithmTest extends TestCase
         $calendar->setNow(DateTime::fromString('2020-01-01 00:00:00 UTC'));
 
         $this->assertSame(1, $algorithm->capacity('hit_id', $storage = new MemoryStorage($calendar)));
+        $this->assertSame(1, $algorithm->capacityInitial());
+        $this->assertSame(0, $algorithm->resetIn('hit_id', $storage)->inSeconds());
+
         $algorithm->hit('hit_id', $storage);
         $this->assertSame(0, $algorithm->capacity('hit_id', $storage));
 
@@ -88,5 +91,21 @@ final class SlidingWindowAlgorithmTest extends TestCase
         $this->assertSame($algorithm->estimate('hit_id', $storage)->inSeconds(), 0);
 
         $algorithm->hit('hit_id', $storage);
+    }
+
+    public function test_resets_in() : void
+    {
+        $algorithm = new SlidingWindowAlgorithm($calendar = new GregorianCalendarStub(TimeZone::UTC()), 1, TimeUnit::minute());
+
+        $calendar->setNow(DateTime::fromString('2020-01-01 00:00:00 UTC'));
+
+        $this->assertSame(1, $algorithm->capacity('hit_id', $storage = new MemoryStorage($calendar)));
+        $algorithm->hit('hit_id', $storage);
+        $this->assertSame(0, $algorithm->capacity('hit_id', $storage));
+        $this->assertSame(60, $algorithm->resetIn('hit_id', $storage)->inSeconds());
+
+        $calendar->setNow($calendar->now()->add(TimeUnit::seconds(61)));
+
+        $this->assertSame(1, $algorithm->capacity('hit_id', $storage));
     }
 }

--- a/tests/Aeon/RateLimiter/Tests/Unit/HitsTest.php
+++ b/tests/Aeon/RateLimiter/Tests/Unit/HitsTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Aeon\RateLimiter\Tests\Unit;
 
 use Aeon\Calendar\Gregorian\DateTime;
+use Aeon\Calendar\Gregorian\GregorianCalendarStub;
+use Aeon\Calendar\Gregorian\TimeZone;
 use Aeon\Calendar\TimeUnit;
 use Aeon\RateLimiter\Hit;
 use Aeon\RateLimiter\Hits;
@@ -31,5 +33,18 @@ final class HitsTest extends TestCase
         );
 
         $this->assertSame($hits->oldest(), $hit2);
+    }
+
+    public function test_longest_ttl() : void
+    {
+        $calendar = new GregorianCalendarStub(TimeZone::UTC());
+        $calendar->setNow(DateTime::fromString('2020-01-01 00:04:00 UTC'));
+        $hits = new Hits(
+            $hit1 = new Hit('id', DateTime::fromString('2020-01-01 00:03:00 UTC'), TimeUnit::minute()),
+            $hit2 = new Hit('id', DateTime::fromString('2020-01-01 00:00:00 UTC'), TimeUnit::minutes(5)),
+            $hit3 = new Hit('id', DateTime::fromString('2020-01-01 00:01:00 UTC'), TimeUnit::minute()),
+        );
+
+        $this->assertSame(1, $hits->longestTTL($calendar)->inMinutes());
     }
 }

--- a/tests/Aeon/RateLimiter/Tests/Unit/RateLimiterTest.php
+++ b/tests/Aeon/RateLimiter/Tests/Unit/RateLimiterTest.php
@@ -71,6 +71,19 @@ final class RateLimiterTest extends TestCase
         $this->assertSame(10, $rateLimiter->capacity('id'));
     }
 
+    public function test_capacity_initial() : void
+    {
+        $algorithm = $this->createStub(Algorithm::class);
+        $algorithm->method('capacityInitial')->willReturn(10);
+
+        $rateLimiter = new RateLimiter(
+            $algorithm,
+            $this->createMock(Storage::class)
+        );
+
+        $this->assertSame(10, $rateLimiter->capacityInitial());
+    }
+
     public function test_throttle_and_wait() : void
     {
         $algorithm = $this->createMock(Algorithm::class);
@@ -90,5 +103,18 @@ final class RateLimiterTest extends TestCase
         $process->expects($this->once())->method('sleep')->with($sleepTime);
 
         $rateLimiter->throttle('id', $process);
+    }
+
+    public function test_resets_in() : void
+    {
+        $algorithm = $this->createStub(Algorithm::class);
+        $algorithm->method('resetIn')->willReturn(TimeUnit::seconds(10));
+
+        $rateLimiter = new RateLimiter(
+            $algorithm,
+            $this->createMock(Storage::class)
+        );
+
+        $this->assertSame(10, $rateLimiter->resetIn('id')->inSeconds());
     }
 }


### PR DESCRIPTION
Those two methods are required to satisfy following HTTP headers: 

```
X-RateLimit-Reset
X-RateLimit-Limit
```

The first one stands for the time to reset rate limit, second represents initial capacity. 