### PR TITLE
Add constraints for psr/cache 2.x & 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "ext-json": "*",
     "aeon-php/calendar": "^1.0",
     "aeon-php/sleep": ">=0.6.0",
-    "psr/cache": "^1.0",
+    "psr/cache": "^1.0|^2.0|^3.0",
     "symfony/polyfill-mbstring": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <li>Constraints for <code>psr-cache</code> to include v2 & v3</li>
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
<p>Add support for <code>psr/cache</code> v2 & v3 as it is required by later versions of <code>symfony/cache</code>, e.g. 6.x</p>

<p>Related to Symfony 6 support PR https://github.com/aeon-php/symfony-bundle/pull/355</p>